### PR TITLE
Fixed bug in .not()

### DIFF
--- a/dependsOn-1.0.1.js
+++ b/dependsOn-1.0.1.js
@@ -127,6 +127,9 @@
 			, length = checkAgainst.length
 			, i = 0;
 
+		if ( this.$dependencyObj.attr('type') === 'radio' ) {
+			dependencyValue = this.$dependencyObj.filter(':checked').val();
+		}
 		// Loop through list of blacklisted values. Break when we find a match.
 		for ( i; i < length; i += 1 ) {
 			if ( checkAgainst[i] === dependencyValue ) {


### PR DESCRIPTION
Copied the lines which fetch the correct value from radio groups from .values() into .not()