### PR TITLE
Remove visibility check. Closes #39

### DIFF
--- a/src/subject-controller.js
+++ b/src/subject-controller.js
@@ -174,8 +174,8 @@ SubjectController.prototype._toggleDisplay = function(show, noFade) {
 	} else {
 		$hideEle = this.$subject.add('label[for="' + id + '"]')
 	}
-
-	if (show && !$hideEle.is(':visible')) {
+	
+	if (show) {
 		if (noFade) {
 			$hideEle.show()
 		} else {


### PR DESCRIPTION
This causes issues when two dependencies are applying show/hide logic at the same time.